### PR TITLE
Remove alpha2 duplicate option for English language

### DIFF
--- a/lib/languages.dart
+++ b/lib/languages.dart
@@ -54,7 +54,6 @@ final List defaultLanguagesList = [
   {"isoCode": "dv", "name": "Dhivehi"},
   {"isoCode": "nl", "name": "Dutch"},
   {"isoCode": "dz", "name": "Dzongkha"},
-  {"isoCode": "alpha2", "name": "English"},
   {"isoCode": "en", "name": "English"},
   {"isoCode": "eo", "name": "Esperanto"},
   {"isoCode": "et", "name": "Estonian"},


### PR DESCRIPTION
This PR removes the "English" language option which is mapped to `alpha2` isoCode.
In the current version users select "English" but `alpha2` language code is returned which is not expected.