### PR TITLE
Add publish workflow for pub.dev

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Publish
+        run: dart pub publish --force

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write # Required for authentication using OIDC
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds a GitHub Actions workflow that publishes the package to pub.dev automatically when a version tag (like `v0.3.0`) is pushed.

To use it:
1. Merge this PR.
2. On pub.dev, enable automated publishing from GitHub Actions for this repository (Admin tab of the package page, tag pattern `v{{version}}`).
3. Create a GitHub release with tag `v0.3.0` — the workflow does the rest.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Qdqi6wtQB3iPSAiFQzm89)_